### PR TITLE
Re-Enable OTEL

### DIFF
--- a/drizzle-orm/src/tracing.ts
+++ b/drizzle-orm/src/tracing.ts
@@ -4,13 +4,13 @@ import { npmVersion } from '~/version.ts';
 
 let otel: typeof import('@opentelemetry/api') | undefined;
 let rawTracer: Tracer | undefined;
-// try {
-// 	otel = await import('@opentelemetry/api');
-// } catch (err: any) {
-// 	if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
-// 		throw err;
-// 	}
-// }
+try {
+	otel = await import('@opentelemetry/api');
+} catch (err: any) {
+	if (err.code !== 'MODULE_NOT_FOUND' && err.code !== 'ERR_MODULE_NOT_FOUND') {
+		throw err;
+	}
+}
 
 type SpanName =
 	| 'drizzle.operation'


### PR DESCRIPTION
Re-Enable OTEL as since 2023 support for top-level await has become quite common. And at least in my debugging of the built output, this is the only thing stopping OTEL integration for drizzle.

As of NodeJS 16 it is supported with the `type: { "module" }` configuration [which drizzle-orm uses](https://github.com/drizzle-team/drizzle-orm/blob/main/drizzle-orm/package.json#L5)

Sources for support:
- Compatibility table in https://stackoverflow.com/a/56590390/1890717